### PR TITLE
Fix missing import

### DIFF
--- a/modelchimp/event_queue.py
+++ b/modelchimp/event_queue.py
@@ -1,4 +1,4 @@
-from queue import Queue
+from queue import Queue, Full
 
 
 class EventQueue(object):


### PR DESCRIPTION
This fixes a bug which occurs whenever `EventQueue` is full (e.g., when `add_metric()` is repeatedly called within short time intervals).